### PR TITLE
found a more elegant format for MoC atoms

### DIFF
--- a/src/ForSyDe/Atom/MoC.hs
+++ b/src/ForSyDe/Atom/MoC.hs
@@ -213,7 +213,7 @@ class MoC e where
   -- The reason why &#946; is not extended is to allow for the
   -- composition of generic process constructors with arbitrary number
   -- of arguments.
-  (-$-) :: (Context e, [Value a] -> b) -> Signal (e [Value a]) -> (Context e, Signal (e b))
+  (-$-) :: (Context e, [Value a] -> b) -> Signal (e [Value a]) -> Signal (e b)
 
   -- | This is a rough equivalent of the @(\<*\>)@ applicative functor
   -- operator, used for synchronizing and applying a signal of
@@ -225,7 +225,7 @@ class MoC e where
   -- The reason why &#946; is not extended is to allow for the
   -- composition of generic process constructors with arbitrary number
   -- of arguments.
-  (-*-) :: (Context e, Signal (e ([Value a] -> b))) -> Signal (e [Value a]) -> (Context e, Signal (e b))
+  (-*-) :: (Signal (e (Context e, [Value a] -> b))) -> Signal (e [Value a]) -> Signal (e b)
 
   -- | Since ForSyDe signals are modeled similar to
   -- <https://www.cs.ox.ac.uk/files/3378/PRG56.pdf Bird lists>, the
@@ -264,15 +264,15 @@ instance (Eq a, MoC e)  => Eq (Signal (e [a])) where
     where flat = concat . map fromEvent . fromSignal
 
 infixl 3 -¤, -<, -<<, -<<<, -<<<<, -<<<<<, -<<<<<<, -<<<<<<<, -<<<<<<<<
-(-¤)        (_,s) =  s
-(-<)        (_,s) = (s ||<)
-(-<<)       (_,s) = (s ||<<)
-(-<<<)      (_,s) = (s ||<<<)
-(-<<<<)     (_,s) = (s ||<<<<)
-(-<<<<<)    (_,s) = (s ||<<<<<)
-(-<<<<<<)   (_,s) = (s ||<<<<<<)
-(-<<<<<<<)  (_,s) = (s ||<<<<<<<)
-(-<<<<<<<<) (_,s) = (s ||<<<<<<<<)
+(-¤)        (s) =  s
+(-<)        (s) = (s ||<)
+(-<<)       (s) = (s ||<<)
+(-<<<)      (s) = (s ||<<<)
+(-<<<<)     (s) = (s ||<<<<)
+(-<<<<<)    (s) = (s ||<<<<<)
+(-<<<<<<)   (s) = (s ||<<<<<<)
+(-<<<<<<<)  (s) = (s ||<<<<<<<)
+(-<<<<<<<<) (s) = (s ||<<<<<<<<)
 
 
 

--- a/src/ForSyDe/Atom/MoC/CT/Core.hs
+++ b/src/ForSyDe/Atom/MoC/CT/Core.hs
@@ -39,9 +39,9 @@ data CT a  = CT { tag :: Time, func :: Time -> a }
 instance MoC CT where
   type Context CT = ()
   ---------------------
-  (-$-) (_,f) = (,) () . (fmap . fmap) f
+  (-$-) (_,f) = (fmap . fmap) f
   ---------------------
-  (_,sf) -*- sx = ((), init ue sf sx)
+  sf -*- sx = init ue (extractFunction <$> sf) sx
     where init px s1@(f :- fs) s2@(x :- xs)
             | tag f == tag x        = f %> f  <*> x  :- comb f  x  fs xs
             | tag f <  tag x        = f %> f  <*> px :- comb f  px fs s2
@@ -90,6 +90,8 @@ infixl 7 %>
 (CT t _) %> (CT _ x) = CT t x
 ue = CT 0.0 (\_ -> [Undef]) :: Event x
 
+extractFunction (CT t f) = CT t (snd . f)
+
 -- end of testbench functions
 -----------------------------------------------------------------------------
 
@@ -126,76 +128,43 @@ partitionUntil until sample (x:-xs) = chunk x xs
 eval s = (\(CT t f) -> f t) <$> s
 
 ----------------------------------------------------------------------------- 
+wrap f = ((), \x -> f x)
 
-wrap11 :: (a1->b1)                             -> ((), [a1]->[b1])
-wrap21 :: (a1->a2->b1)                         -> ((), [a1]->[a2]->[b1])
-wrap31 :: (a1->a2->a3->b1)                     -> ((), [a1]->[a2]->[a3]->[b1])
-wrap41 :: (a1->a2->a3->a4->b1)                 -> ((), [a1]->[a2]->[a3]->[a4]->[b1])
-wrap51 :: (a1->a2->a3->a4->a5->b1)             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[b1])
-wrap61 :: (a1->a2->a3->a4->a5->a6->b1)         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[b1])
-wrap71 :: (a1->a2->a3->a4->a5->a6->a7->b1)     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[b1])
-wrap81 :: (a1->a2->a3->a4->a5->a6->a7->a8->b1) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->[b1])
+wrap11 f = wrap $ (map f)
+wrap21 f = wrap $ wrap11 . f . head 
+wrap31 f = wrap $ wrap21 . f . head
+wrap41 f = wrap $ wrap31 . f . head
+wrap51 f = wrap $ wrap41 . f . head
+wrap61 f = wrap $ wrap51 . f . head
+wrap71 f = wrap $ wrap61 . f . head
+wrap81 f = wrap $ wrap71 . f . head
 
-wrap12 :: (a1->(b1,b2))                             -> ((), [a1]->([b1],[b2]))
-wrap22 :: (a1->a2->(b1,b2))                         -> ((), [a1]->[a2]->([b1],[b2]))
-wrap32 :: (a1->a2->a3->(b1,b2))                     -> ((), [a1]->[a2]->[a3]->([b1],[b2]))
-wrap42 :: (a1->a2->a3->a4->(b1,b2))                 -> ((), [a1]->[a2]->[a3]->[a4]->([b1],[b2]))
-wrap52 :: (a1->a2->a3->a4->a5->(b1,b2))             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->([b1],[b2]))
-wrap62 :: (a1->a2->a3->a4->a5->a6->(b1,b2))         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->([b1],[b2]))
-wrap72 :: (a1->a2->a3->a4->a5->a6->a7->(b1,b2))     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->([b1],[b2]))
-wrap82 :: (a1->a2->a3->a4->a5->a6->a7->a8->(b1,b2)) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->([b1],[b2]))
+wrap12 f = wrap $ ((|<) . map f)
+wrap22 f = wrap $ wrap12 . f . head 
+wrap32 f = wrap $ wrap22 . f . head
+wrap42 f = wrap $ wrap32 . f . head
+wrap52 f = wrap $ wrap42 . f . head
+wrap62 f = wrap $ wrap52 . f . head
+wrap72 f = wrap $ wrap62 . f . head
+wrap82 f = wrap $ wrap72 . f . head
 
-wrap13 :: (a1->(b1,b2,b3))                             -> ((), [a1]->([b1],[b2],[b3]))
-wrap23 :: (a1->a2->(b1,b2,b3))                         -> ((), [a1]->[a2]->([b1],[b2],[b3]))
-wrap33 :: (a1->a2->a3->(b1,b2,b3))                     -> ((), [a1]->[a2]->[a3]->([b1],[b2],[b3]))
-wrap43 :: (a1->a2->a3->a4->(b1,b2,b3))                 -> ((), [a1]->[a2]->[a3]->[a4]->([b1],[b2],[b3]))
-wrap53 :: (a1->a2->a3->a4->a5->(b1,b2,b3))             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->([b1],[b2],[b3]))
-wrap63 :: (a1->a2->a3->a4->a5->a6->(b1,b2,b3))         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->([b1],[b2],[b3]))
-wrap73 :: (a1->a2->a3->a4->a5->a6->a7->(b1,b2,b3))     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->([b1],[b2],[b3]))
-wrap83 :: (a1->a2->a3->a4->a5->a6->a7->a8->(b1,b2,b3)) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->([b1],[b2],[b3]))
+wrap13 f = wrap $ ((|<<) . map f)
+wrap23 f = wrap $ wrap13 . f . head 
+wrap33 f = wrap $ wrap23 . f . head
+wrap43 f = wrap $ wrap33 . f . head
+wrap53 f = wrap $ wrap43 . f . head
+wrap63 f = wrap $ wrap53 . f . head
+wrap73 f = wrap $ wrap63 . f . head
+wrap83 f = wrap $ wrap73 . f . head
 
-wrap14 :: (a1->(b1,b2,b3,b4))                             -> ((), [a1]->([b1],[b2],[b3],[b4]))
-wrap24 :: (a1->a2->(b1,b2,b3,b4))                         -> ((), [a1]->[a2]->([b1],[b2],[b3],[b4]))
-wrap34 :: (a1->a2->a3->(b1,b2,b3,b4))                     -> ((), [a1]->[a2]->[a3]->([b1],[b2],[b3],[b4]))
-wrap44 :: (a1->a2->a3->a4->(b1,b2,b3,b4))                 -> ((), [a1]->[a2]->[a3]->[a4]->([b1],[b2],[b3],[b4]))
-wrap54 :: (a1->a2->a3->a4->a5->(b1,b2,b3,b4))             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->([b1],[b2],[b3],[b4]))
-wrap64 :: (a1->a2->a3->a4->a5->a6->(b1,b2,b3,b4))         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->([b1],[b2],[b3],[b4]))
-wrap74 :: (a1->a2->a3->a4->a5->a6->a7->(b1,b2,b3,b4))     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->([b1],[b2],[b3],[b4]))
-wrap84 :: (a1->a2->a3->a4->a5->a6->a7->a8->(b1,b2,b3,b4)) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->([b1],[b2],[b3],[b4]))
-
-wrap11 = (,) () . psi11
-wrap21 = (,) () . psi21
-wrap31 = (,) () . psi31
-wrap41 = (,) () . psi41
-wrap51 = (,) () . psi51
-wrap61 = (,) () . psi61
-wrap71 = (,) () . psi71
-wrap81 = (,) () . psi81
-wrap12 = (,) () . psi12
-wrap22 = (,) () . psi22
-wrap32 = (,) () . psi32
-wrap42 = (,) () . psi42
-wrap52 = (,) () . psi52
-wrap62 = (,) () . psi62
-wrap72 = (,) () . psi72
-wrap82 = (,) () . psi82
-wrap13 = (,) () . psi13
-wrap23 = (,) () . psi23
-wrap33 = (,) () . psi33
-wrap43 = (,) () . psi43
-wrap53 = (,) () . psi53
-wrap63 = (,) () . psi63
-wrap73 = (,) () . psi73
-wrap83 = (,) () . psi83
-wrap14 = (,) () . psi14
-wrap24 = (,) () . psi24
-wrap34 = (,) () . psi34
-wrap44 = (,) () . psi44
-wrap54 = (,) () . psi54
-wrap64 = (,) () . psi64
-wrap74 = (,) () . psi74
-wrap84 = (,) () . psi84
-
+wrap14 f = wrap $ ((|<<<) . map f)
+wrap24 f = wrap $ wrap14 . f . head 
+wrap34 f = wrap $ wrap24 . f . head
+wrap44 f = wrap $ wrap34 . f . head
+wrap54 f = wrap $ wrap44 . f . head
+wrap64 f = wrap $ wrap54 . f . head
+wrap74 f = wrap $ wrap64 . f . head
+wrap84 f = wrap $ wrap74 . f . head
 
 
 

--- a/src/ForSyDe/Atom/MoC/DE/Core.hs
+++ b/src/ForSyDe/Atom/MoC/DE/Core.hs
@@ -37,9 +37,9 @@ data DE a  = DE { tag :: Tag, val :: a }
 instance MoC DE where
   type Context DE = ()
   ---------------------
-  (-$-) (_,f) = (,) () . (fmap . fmap) f
+  (-$-) (_,f) = (fmap . fmap) f
   ---------------------
-  (_,sf) -*- sx = ((), init ue sf sx)
+  sf -*- sx = init ue (extractFunction <$> sf) sx
     where init px s1@(f :- fs) s2@(x :- xs)
             | tag f == tag x        = f %> f  <*> x  :- comb f  x  fs xs
             | tag f <  tag x        = f %> f  <*> px :- comb f  px fs s2
@@ -95,6 +95,8 @@ infixl 7 %>
 (DE t _) %> (DE _ x) = DE t x
 ue = DE 0 [Undef]
 
+extractFunction (DE t (_,f)) = DE t f
+
 -- end of testbench functions
 -----------------------------------------------------------------------------
 
@@ -112,77 +114,43 @@ signal   :: [(Tag, a)] -> Sig a
 signal l = S.signal (event <$> l)
 
 ----------------------------------------------------------------------------- 
+wrap f = ((), \x -> f x)
 
-wrap11 :: (a1->b1)                             -> ((), [a1]->[b1])
-wrap21 :: (a1->a2->b1)                         -> ((), [a1]->[a2]->[b1])
-wrap31 :: (a1->a2->a3->b1)                     -> ((), [a1]->[a2]->[a3]->[b1])
-wrap41 :: (a1->a2->a3->a4->b1)                 -> ((), [a1]->[a2]->[a3]->[a4]->[b1])
-wrap51 :: (a1->a2->a3->a4->a5->b1)             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[b1])
-wrap61 :: (a1->a2->a3->a4->a5->a6->b1)         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[b1])
-wrap71 :: (a1->a2->a3->a4->a5->a6->a7->b1)     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[b1])
-wrap81 :: (a1->a2->a3->a4->a5->a6->a7->a8->b1) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->[b1])
+wrap11 f = wrap $ (map f)
+wrap21 f = wrap $ wrap11 . f . head 
+wrap31 f = wrap $ wrap21 . f . head
+wrap41 f = wrap $ wrap31 . f . head
+wrap51 f = wrap $ wrap41 . f . head
+wrap61 f = wrap $ wrap51 . f . head
+wrap71 f = wrap $ wrap61 . f . head
+wrap81 f = wrap $ wrap71 . f . head
 
-wrap12 :: (a1->(b1,b2))                             -> ((), [a1]->([b1],[b2]))
-wrap22 :: (a1->a2->(b1,b2))                         -> ((), [a1]->[a2]->([b1],[b2]))
-wrap32 :: (a1->a2->a3->(b1,b2))                     -> ((), [a1]->[a2]->[a3]->([b1],[b2]))
-wrap42 :: (a1->a2->a3->a4->(b1,b2))                 -> ((), [a1]->[a2]->[a3]->[a4]->([b1],[b2]))
-wrap52 :: (a1->a2->a3->a4->a5->(b1,b2))             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->([b1],[b2]))
-wrap62 :: (a1->a2->a3->a4->a5->a6->(b1,b2))         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->([b1],[b2]))
-wrap72 :: (a1->a2->a3->a4->a5->a6->a7->(b1,b2))     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->([b1],[b2]))
-wrap82 :: (a1->a2->a3->a4->a5->a6->a7->a8->(b1,b2)) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->([b1],[b2]))
+wrap12 f = wrap $ ((|<) . map f)
+wrap22 f = wrap $ wrap12 . f . head 
+wrap32 f = wrap $ wrap22 . f . head
+wrap42 f = wrap $ wrap32 . f . head
+wrap52 f = wrap $ wrap42 . f . head
+wrap62 f = wrap $ wrap52 . f . head
+wrap72 f = wrap $ wrap62 . f . head
+wrap82 f = wrap $ wrap72 . f . head
 
-wrap13 :: (a1->(b1,b2,b3))                             -> ((), [a1]->([b1],[b2],[b3]))
-wrap23 :: (a1->a2->(b1,b2,b3))                         -> ((), [a1]->[a2]->([b1],[b2],[b3]))
-wrap33 :: (a1->a2->a3->(b1,b2,b3))                     -> ((), [a1]->[a2]->[a3]->([b1],[b2],[b3]))
-wrap43 :: (a1->a2->a3->a4->(b1,b2,b3))                 -> ((), [a1]->[a2]->[a3]->[a4]->([b1],[b2],[b3]))
-wrap53 :: (a1->a2->a3->a4->a5->(b1,b2,b3))             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->([b1],[b2],[b3]))
-wrap63 :: (a1->a2->a3->a4->a5->a6->(b1,b2,b3))         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->([b1],[b2],[b3]))
-wrap73 :: (a1->a2->a3->a4->a5->a6->a7->(b1,b2,b3))     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->([b1],[b2],[b3]))
-wrap83 :: (a1->a2->a3->a4->a5->a6->a7->a8->(b1,b2,b3)) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->([b1],[b2],[b3]))
+wrap13 f = wrap $ ((|<<) . map f)
+wrap23 f = wrap $ wrap13 . f . head 
+wrap33 f = wrap $ wrap23 . f . head
+wrap43 f = wrap $ wrap33 . f . head
+wrap53 f = wrap $ wrap43 . f . head
+wrap63 f = wrap $ wrap53 . f . head
+wrap73 f = wrap $ wrap63 . f . head
+wrap83 f = wrap $ wrap73 . f . head
 
-wrap14 :: (a1->(b1,b2,b3,b4))                             -> ((), [a1]->([b1],[b2],[b3],[b4]))
-wrap24 :: (a1->a2->(b1,b2,b3,b4))                         -> ((), [a1]->[a2]->([b1],[b2],[b3],[b4]))
-wrap34 :: (a1->a2->a3->(b1,b2,b3,b4))                     -> ((), [a1]->[a2]->[a3]->([b1],[b2],[b3],[b4]))
-wrap44 :: (a1->a2->a3->a4->(b1,b2,b3,b4))                 -> ((), [a1]->[a2]->[a3]->[a4]->([b1],[b2],[b3],[b4]))
-wrap54 :: (a1->a2->a3->a4->a5->(b1,b2,b3,b4))             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->([b1],[b2],[b3],[b4]))
-wrap64 :: (a1->a2->a3->a4->a5->a6->(b1,b2,b3,b4))         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->([b1],[b2],[b3],[b4]))
-wrap74 :: (a1->a2->a3->a4->a5->a6->a7->(b1,b2,b3,b4))     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->([b1],[b2],[b3],[b4]))
-wrap84 :: (a1->a2->a3->a4->a5->a6->a7->a8->(b1,b2,b3,b4)) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->([b1],[b2],[b3],[b4]))
-
-wrap11 = (,) () . psi11
-wrap21 = (,) () . psi21
-wrap31 = (,) () . psi31
-wrap41 = (,) () . psi41
-wrap51 = (,) () . psi51
-wrap61 = (,) () . psi61
-wrap71 = (,) () . psi71
-wrap81 = (,) () . psi81
-wrap12 = (,) () . psi12
-wrap22 = (,) () . psi22
-wrap32 = (,) () . psi32
-wrap42 = (,) () . psi42
-wrap52 = (,) () . psi52
-wrap62 = (,) () . psi62
-wrap72 = (,) () . psi72
-wrap82 = (,) () . psi82
-wrap13 = (,) () . psi13
-wrap23 = (,) () . psi23
-wrap33 = (,) () . psi33
-wrap43 = (,) () . psi43
-wrap53 = (,) () . psi53
-wrap63 = (,) () . psi63
-wrap73 = (,) () . psi73
-wrap83 = (,) () . psi83
-wrap14 = (,) () . psi14
-wrap24 = (,) () . psi24
-wrap34 = (,) () . psi34
-wrap44 = (,) () . psi44
-wrap54 = (,) () . psi54
-wrap64 = (,) () . psi64
-wrap74 = (,) () . psi74
-wrap84 = (,) () . psi84
-
-
+wrap14 f = wrap $ ((|<<<) . map f)
+wrap24 f = wrap $ wrap14 . f . head 
+wrap34 f = wrap $ wrap24 . f . head
+wrap44 f = wrap $ wrap34 . f . head
+wrap54 f = wrap $ wrap44 . f . head
+wrap64 f = wrap $ wrap54 . f . head
+wrap74 f = wrap $ wrap64 . f . head
+wrap84 f = wrap $ wrap74 . f . head
 
     -- where init (DE ptx px) s1@(DE tf f :- fs) s2@(DE tx x :- xs)
     --         | tf == tx = DE tf (f  x) :- comb (DE tf f) (DE  tx  x) fs xs

--- a/src/ForSyDe/Atom/MoC/SY/Core.hs
+++ b/src/ForSyDe/Atom/MoC/SY/Core.hs
@@ -38,9 +38,9 @@ newtype SY a  = SY { fromSY :: a }
 instance MoC SY where
   type Context SY = ()
   ---------------------
-  (-$-) (_,f) = (,) () . (fmap . fmap) f
+  (-$-) (_,f) = (fmap . fmap) f
   ---------------------
-  (-*-) (_,fs) = (,) () . (<*>) (fmap (\f x -> f <*> x) fs)
+  (-*-) fs = (<*>) (fmap (\f x -> f <*> x) (extractFunction <$> fs))
   ---------------------
   (->-) = (:-) 
   ---------------------
@@ -88,6 +88,8 @@ part = SY . pure
 stream :: [a] -> Signal (SY [a])
 stream l = S.signal (part <$> l)
 
+extractFunction (SY (_,f)) = SY f
+
 -- end of testbench functions
 -----------------------------------------------------------------------------
 
@@ -102,73 +104,40 @@ signal   :: [a] -> Sig a
 signal l = S.signal (event <$> l)
 
 -----------------------------------------------------------------------------
+wrap f = ((), \x -> f x)
 
-wrap11 :: (a1->b1)                             -> ((), [a1]->[b1])
-wrap21 :: (a1->a2->b1)                         -> ((), [a1]->[a2]->[b1])
-wrap31 :: (a1->a2->a3->b1)                     -> ((), [a1]->[a2]->[a3]->[b1])
-wrap41 :: (a1->a2->a3->a4->b1)                 -> ((), [a1]->[a2]->[a3]->[a4]->[b1])
-wrap51 :: (a1->a2->a3->a4->a5->b1)             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[b1])
-wrap61 :: (a1->a2->a3->a4->a5->a6->b1)         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[b1])
-wrap71 :: (a1->a2->a3->a4->a5->a6->a7->b1)     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[b1])
-wrap81 :: (a1->a2->a3->a4->a5->a6->a7->a8->b1) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->[b1])
+wrap11 f = wrap $ (map f)
+wrap21 f = wrap $ wrap11 . f . head 
+wrap31 f = wrap $ wrap21 . f . head
+wrap41 f = wrap $ wrap31 . f . head
+wrap51 f = wrap $ wrap41 . f . head
+wrap61 f = wrap $ wrap51 . f . head
+wrap71 f = wrap $ wrap61 . f . head
+wrap81 f = wrap $ wrap71 . f . head
 
-wrap12 :: (a1->(b1,b2))                             -> ((), [a1]->([b1],[b2]))
-wrap22 :: (a1->a2->(b1,b2))                         -> ((), [a1]->[a2]->([b1],[b2]))
-wrap32 :: (a1->a2->a3->(b1,b2))                     -> ((), [a1]->[a2]->[a3]->([b1],[b2]))
-wrap42 :: (a1->a2->a3->a4->(b1,b2))                 -> ((), [a1]->[a2]->[a3]->[a4]->([b1],[b2]))
-wrap52 :: (a1->a2->a3->a4->a5->(b1,b2))             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->([b1],[b2]))
-wrap62 :: (a1->a2->a3->a4->a5->a6->(b1,b2))         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->([b1],[b2]))
-wrap72 :: (a1->a2->a3->a4->a5->a6->a7->(b1,b2))     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->([b1],[b2]))
-wrap82 :: (a1->a2->a3->a4->a5->a6->a7->a8->(b1,b2)) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->([b1],[b2]))
+wrap12 f = wrap $ ((|<) . map f)
+wrap22 f = wrap $ wrap12 . f . head 
+wrap32 f = wrap $ wrap22 . f . head
+wrap42 f = wrap $ wrap32 . f . head
+wrap52 f = wrap $ wrap42 . f . head
+wrap62 f = wrap $ wrap52 . f . head
+wrap72 f = wrap $ wrap62 . f . head
+wrap82 f = wrap $ wrap72 . f . head
 
-wrap13 :: (a1->(b1,b2,b3))                             -> ((), [a1]->([b1],[b2],[b3]))
-wrap23 :: (a1->a2->(b1,b2,b3))                         -> ((), [a1]->[a2]->([b1],[b2],[b3]))
-wrap33 :: (a1->a2->a3->(b1,b2,b3))                     -> ((), [a1]->[a2]->[a3]->([b1],[b2],[b3]))
-wrap43 :: (a1->a2->a3->a4->(b1,b2,b3))                 -> ((), [a1]->[a2]->[a3]->[a4]->([b1],[b2],[b3]))
-wrap53 :: (a1->a2->a3->a4->a5->(b1,b2,b3))             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->([b1],[b2],[b3]))
-wrap63 :: (a1->a2->a3->a4->a5->a6->(b1,b2,b3))         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->([b1],[b2],[b3]))
-wrap73 :: (a1->a2->a3->a4->a5->a6->a7->(b1,b2,b3))     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->([b1],[b2],[b3]))
-wrap83 :: (a1->a2->a3->a4->a5->a6->a7->a8->(b1,b2,b3)) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->([b1],[b2],[b3]))
+wrap13 f = wrap $ ((|<<) . map f)
+wrap23 f = wrap $ wrap13 . f . head 
+wrap33 f = wrap $ wrap23 . f . head
+wrap43 f = wrap $ wrap33 . f . head
+wrap53 f = wrap $ wrap43 . f . head
+wrap63 f = wrap $ wrap53 . f . head
+wrap73 f = wrap $ wrap63 . f . head
+wrap83 f = wrap $ wrap73 . f . head
 
-wrap14 :: (a1->(b1,b2,b3,b4))                             -> ((), [a1]->([b1],[b2],[b3],[b4]))
-wrap24 :: (a1->a2->(b1,b2,b3,b4))                         -> ((), [a1]->[a2]->([b1],[b2],[b3],[b4]))
-wrap34 :: (a1->a2->a3->(b1,b2,b3,b4))                     -> ((), [a1]->[a2]->[a3]->([b1],[b2],[b3],[b4]))
-wrap44 :: (a1->a2->a3->a4->(b1,b2,b3,b4))                 -> ((), [a1]->[a2]->[a3]->[a4]->([b1],[b2],[b3],[b4]))
-wrap54 :: (a1->a2->a3->a4->a5->(b1,b2,b3,b4))             -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->([b1],[b2],[b3],[b4]))
-wrap64 :: (a1->a2->a3->a4->a5->a6->(b1,b2,b3,b4))         -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->([b1],[b2],[b3],[b4]))
-wrap74 :: (a1->a2->a3->a4->a5->a6->a7->(b1,b2,b3,b4))     -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->([b1],[b2],[b3],[b4]))
-wrap84 :: (a1->a2->a3->a4->a5->a6->a7->a8->(b1,b2,b3,b4)) -> ((), [a1]->[a2]->[a3]->[a4]->[a5]->[a6]->[a7]->[a8]->([b1],[b2],[b3],[b4]))
-
-wrap11 = (,) () . psi11
-wrap21 = (,) () . psi21
-wrap31 = (,) () . psi31
-wrap41 = (,) () . psi41
-wrap51 = (,) () . psi51
-wrap61 = (,) () . psi61
-wrap71 = (,) () . psi71
-wrap81 = (,) () . psi81
-wrap12 = (,) () . psi12
-wrap22 = (,) () . psi22
-wrap32 = (,) () . psi32
-wrap42 = (,) () . psi42
-wrap52 = (,) () . psi52
-wrap62 = (,) () . psi62
-wrap72 = (,) () . psi72
-wrap82 = (,) () . psi82
-wrap13 = (,) () . psi13
-wrap23 = (,) () . psi23
-wrap33 = (,) () . psi33
-wrap43 = (,) () . psi43
-wrap53 = (,) () . psi53
-wrap63 = (,) () . psi63
-wrap73 = (,) () . psi73
-wrap83 = (,) () . psi83
-wrap14 = (,) () . psi14
-wrap24 = (,) () . psi24
-wrap34 = (,) () . psi34
-wrap44 = (,) () . psi44
-wrap54 = (,) () . psi54
-wrap64 = (,) () . psi64
-wrap74 = (,) () . psi74
-wrap84 = (,) () . psi84
-
+wrap14 f = wrap $ ((|<<<) . map f)
+wrap24 f = wrap $ wrap14 . f . head 
+wrap34 f = wrap $ wrap24 . f . head
+wrap44 f = wrap $ wrap34 . f . head
+wrap54 f = wrap $ wrap44 . f . head
+wrap64 f = wrap $ wrap54 . f . head
+wrap74 f = wrap $ wrap64 . f . head
+wrap84 f = wrap $ wrap74 . f . head


### PR DESCRIPTION
This new approach (derived from Alternative 6 in [this wiki log](https://github.com/forsyde/forsyde-atom/wiki/The-true-meaning-of-production-and-consumption-rates)) not only does it seem to work, but it also enforces the idea that atoms are self-sufficient and independent. Now we are not force to pass around an "environment" just for the sake of providing a context (e.g. parameters) to a network pattern. The new wrapper magic takes care of individually tupling of each argument of a function with the necessary context.